### PR TITLE
feat: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,0 +1,40 @@
+name: Bug Report
+description: Let us know about a bug
+labels:
+  - bug
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What is the issue?
+      description: |
+        Describe the bug here. Please provide as much information as possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What is the expected behavior?
+      description: |
+        Please describe the expected behavior here.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: How can we reproduce the bug?
+      description: |
+        Include repro steps and associated relevant information here.
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: notes
+      description: |
+        Any additional information should be included here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,0 +1,40 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What should this feature do?
+      description: |
+        Describe the feature or enhancement (what it should do, etc.) here.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is it needed?
+      description: |
+        Include information about why the feature should be implemented here.
+    validations:
+      required: true
+
+  - type: textarea
+    id: how
+    attributes:
+      label: How should it be implemented?
+      description: |
+        If known, any suggestions / ideas on how the feature could implemented.
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: |
+        Any additional information should be included here.
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ We ask that all contributors review and agree to adhere to our code of conduct p
 ## License
 
 ```
-Copyright 2024 LY Corporation
+Copyright 2024 - 2025 LY Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Issue

N/A

## Summary

- This PR adds issue templates to the project.

## Changes

- Two issue templates were created:
  + feature request
  + bug report
- The copyright year was updated to include 2025.

## Notes / References

- I opted to use [issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) as the template format, instead of Markdown.
  + This allows us to better control the format of issues that are submitted.

## Checklist

- [x] Link to issue specified (N/A)
- [x] Implementation satisfies the stated objective(s)
- [x] Test(s) added as appropriate (N/A)
- [x] Documentation created/updated