### PR TITLE
Lock up jackson dependency

### DIFF
--- a/.idea/geojson-kt.iml
+++ b/.idea/geojson-kt.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id="geojson-kt" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/src/main/kotlin/jp/co/lycorp/geojson/BBox.kt
+++ b/src/main/kotlin/jp/co/lycorp/geojson/BBox.kt
@@ -1,10 +1,5 @@
 package jp.co.lycorp.geojson
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.databind.annotation.JsonSerialize
-import jp.co.lycorp.geojson.jackson.BBoxDeserializer
-import jp.co.lycorp.geojson.jackson.BBoxSerializer
-
 /**
  * BBox class
  *
@@ -17,8 +12,6 @@ import jp.co.lycorp.geojson.jackson.BBoxSerializer
  * @property minAlt Altitude of the most southwesterly point (optional)
  * @property maxAlt Altitude of the most northeasterly point (optional)
  */
-@JsonDeserialize(using = BBoxDeserializer::class)
-@JsonSerialize(using = BBoxSerializer::class)
 data class BBox(
     val minLng: Double,
     val minLat: Double,

--- a/src/main/kotlin/jp/co/lycorp/geojson/Feature.kt
+++ b/src/main/kotlin/jp/co/lycorp/geojson/Feature.kt
@@ -1,9 +1,5 @@
 package jp.co.lycorp.geojson
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.databind.annotation.JsonSerialize
-import jp.co.lycorp.geojson.jackson.FeatureIdDeserializer
-import jp.co.lycorp.geojson.jackson.FeatureIdSerializer
 /**
  * Feature class
  *
@@ -17,8 +13,6 @@ data class Feature(
     val geometry: Geometry<*>,
     override val bbox: BBox? = null,
     val properties: Map<String, Any>? = null,
-    @JsonDeserialize(using = FeatureIdDeserializer::class)
-    @JsonSerialize(using = FeatureIdSerializer::class)
     val id: FeatureId? = null,
 ) : GeoJsonObject("Feature") {
     /**

--- a/src/main/kotlin/jp/co/lycorp/geojson/GeoJsonObject.kt
+++ b/src/main/kotlin/jp/co/lycorp/geojson/GeoJsonObject.kt
@@ -1,7 +1,5 @@
 package jp.co.lycorp.geojson
 
-import com.fasterxml.jackson.annotation.JsonInclude
-
 /**
  *
  * GeoJsonObject class
@@ -11,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
  * @property type Type that GeoJSON has
  * @property bbox Information on the coordinate range for its Geometries, Features, or FeatureCollections
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 abstract class GeoJsonObject(
     val type: String,
     open val bbox: BBox? = null,

--- a/src/main/kotlin/jp/co/lycorp/geojson/GeoJsonObject.kt
+++ b/src/main/kotlin/jp/co/lycorp/geojson/GeoJsonObject.kt
@@ -1,8 +1,6 @@
 package jp.co.lycorp.geojson
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.annotation.JsonSubTypes
-import com.fasterxml.jackson.annotation.JsonTypeInfo
 
 /**
  *
@@ -13,17 +11,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
  * @property type Type that GeoJSON has
  * @property bbox Information on the coordinate range for its Geometries, Features, or FeatureCollections
  */
-@JsonTypeInfo(property = "type", use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY)
-@JsonSubTypes(
-    JsonSubTypes.Type(Point::class, name = "Point"),
-    JsonSubTypes.Type(MultiPoint::class, name = "MultiPoint"),
-    JsonSubTypes.Type(LineString::class, name = "LineString"),
-    JsonSubTypes.Type(MultiLineString::class, name = "MultiLineString"),
-    JsonSubTypes.Type(Polygon::class, name = "Polygon"),
-    JsonSubTypes.Type(MultiPolygon::class, name = "MultiPolygon"),
-    JsonSubTypes.Type(Feature::class, name = "Feature"),
-    JsonSubTypes.Type(FeatureCollection::class, name = "FeatureCollection"),
-)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 abstract class GeoJsonObject(
     val type: String,

--- a/src/main/kotlin/jp/co/lycorp/geojson/Position.kt
+++ b/src/main/kotlin/jp/co/lycorp/geojson/Position.kt
@@ -1,9 +1,5 @@
 package jp.co.lycorp.geojson
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.databind.annotation.JsonSerialize
-import jp.co.lycorp.geojson.jackson.PositionDeserializer
-import jp.co.lycorp.geojson.jackson.PositionSerializer
 import jp.co.lycorp.geojson.validator.PositionValidator
 
 /**
@@ -15,8 +11,6 @@ import jp.co.lycorp.geojson.validator.PositionValidator
  * @property lat Latitude
  * @property alt Altitude (optional)
  */
-@JsonDeserialize(using = PositionDeserializer::class)
-@JsonSerialize(using = PositionSerializer::class)
 data class Position(
     val lng: Double,
     val lat: Double,

--- a/src/main/kotlin/jp/co/lycorp/geojson/jackson/FeatureIdDeserializer.kt
+++ b/src/main/kotlin/jp/co/lycorp/geojson/jackson/FeatureIdDeserializer.kt
@@ -10,7 +10,7 @@ import jp.co.lycorp.geojson.FeatureId
  *
  * Custom deserializer for feature id.
  */
-internal class FeatureIdDeserializer : StdDeserializer<Any?>(FeatureId::class.java) {
+internal class FeatureIdDeserializer : StdDeserializer<FeatureId>(FeatureId::class.java) {
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): FeatureId {
         return when {
             p.currentToken.isNumeric -> FeatureId.of(p.numberValue)

--- a/src/main/kotlin/jp/co/lycorp/geojson/jackson/GeoJsonModule.kt
+++ b/src/main/kotlin/jp/co/lycorp/geojson/jackson/GeoJsonModule.kt
@@ -1,10 +1,14 @@
 package jp.co.lycorp.geojson.jackson
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.introspect.Annotated
+import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector
 import com.fasterxml.jackson.databind.module.SimpleDeserializers
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.module.SimpleSerializers
 import jp.co.lycorp.geojson.BBox
 import jp.co.lycorp.geojson.FeatureId
+import jp.co.lycorp.geojson.GeoJsonObject
 import jp.co.lycorp.geojson.Geometry
 import jp.co.lycorp.geojson.Position
 
@@ -28,5 +32,17 @@ class GeoJsonModule : SimpleModule() {
         serializers.addSerializer(FeatureId::class.java, FeatureIdSerializer())
         serializers.addSerializer(Position::class.java, PositionSerializer())
         context.addSerializers(serializers)
+
+        context.insertAnnotationIntrospector(object : NopAnnotationIntrospector() {
+            override fun findPropertyInclusion(a: Annotated?): JsonInclude.Value? {
+                val rawType = a?.rawType ?: return null
+
+                return if (GeoJsonObject::class.java.isAssignableFrom(rawType)) {
+                    JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL)
+                } else {
+                    null
+                }
+            }
+        })
     }
 }

--- a/src/main/kotlin/jp/co/lycorp/geojson/jackson/GeoJsonModule.kt
+++ b/src/main/kotlin/jp/co/lycorp/geojson/jackson/GeoJsonModule.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.module.SimpleSerializers
 import jp.co.lycorp.geojson.BBox
 import jp.co.lycorp.geojson.FeatureId
+import jp.co.lycorp.geojson.Geometry
 import jp.co.lycorp.geojson.Position
 
 /**
@@ -12,10 +13,14 @@ import jp.co.lycorp.geojson.Position
  */
 class GeoJsonModule : SimpleModule() {
     override fun setupModule(context: SetupContext) {
+        super.setupModule(context)
+
         val deserializers = SimpleDeserializers()
         deserializers.addDeserializer(BBox::class.java, BBoxDeserializer())
         deserializers.addDeserializer(FeatureId::class.java, FeatureIdDeserializer())
         deserializers.addDeserializer(Position::class.java, PositionDeserializer())
+        deserializers.addDeserializer(Geometry::class.java, GoeJsonObjectDeserializer())
+
         context.addDeserializers(deserializers)
 
         val serializers = SimpleSerializers()

--- a/src/main/kotlin/jp/co/lycorp/geojson/jackson/GeoJsonModule.kt
+++ b/src/main/kotlin/jp/co/lycorp/geojson/jackson/GeoJsonModule.kt
@@ -23,7 +23,7 @@ class GeoJsonModule : SimpleModule() {
         deserializers.addDeserializer(BBox::class.java, BBoxDeserializer())
         deserializers.addDeserializer(FeatureId::class.java, FeatureIdDeserializer())
         deserializers.addDeserializer(Position::class.java, PositionDeserializer())
-        deserializers.addDeserializer(Geometry::class.java, GoeJsonObjectDeserializer())
+        deserializers.addDeserializer(Geometry::class.java, GeoJsonObjectDeserializer())
 
         context.addDeserializers(deserializers)
 

--- a/src/main/kotlin/jp/co/lycorp/geojson/jackson/GeoJsonModule.kt
+++ b/src/main/kotlin/jp/co/lycorp/geojson/jackson/GeoJsonModule.kt
@@ -1,0 +1,27 @@
+package jp.co.lycorp.geojson.jackson
+
+import com.fasterxml.jackson.databind.module.SimpleDeserializers
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.databind.module.SimpleSerializers
+import jp.co.lycorp.geojson.BBox
+import jp.co.lycorp.geojson.FeatureId
+import jp.co.lycorp.geojson.Position
+
+/**
+ * Jackson module to install all serializers and deserializers for GeoJSON.
+ */
+class GeoJsonModule : SimpleModule() {
+    override fun setupModule(context: SetupContext) {
+        val deserializers = SimpleDeserializers()
+        deserializers.addDeserializer(BBox::class.java, BBoxDeserializer())
+        deserializers.addDeserializer(FeatureId::class.java, FeatureIdDeserializer())
+        deserializers.addDeserializer(Position::class.java, PositionDeserializer())
+        context.addDeserializers(deserializers)
+
+        val serializers = SimpleSerializers()
+        serializers.addSerializer(BBox::class.java, BBoxSerializer())
+        serializers.addSerializer(FeatureId::class.java, FeatureIdSerializer())
+        serializers.addSerializer(Position::class.java, PositionSerializer())
+        context.addSerializers(serializers)
+    }
+}

--- a/src/main/kotlin/jp/co/lycorp/geojson/jackson/GeoJsonObjectDeserializer.kt
+++ b/src/main/kotlin/jp/co/lycorp/geojson/jackson/GeoJsonObjectDeserializer.kt
@@ -18,7 +18,7 @@ import jp.co.lycorp.geojson.Polygon
 /**
  * Deserializer for all GeoJSON objects.
  */
-class GoeJsonObjectDeserializer<T : GeoJsonObject> : JsonDeserializer<T>() {
+class GeoJsonObjectDeserializer<T : GeoJsonObject> : JsonDeserializer<T>() {
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): T {
         val node: JsonNode = p.codec.readTree(p)
         val type = node.get("type")?.asText()

--- a/src/main/kotlin/jp/co/lycorp/geojson/jackson/GoeJsonObjectDeserializer.kt
+++ b/src/main/kotlin/jp/co/lycorp/geojson/jackson/GoeJsonObjectDeserializer.kt
@@ -16,7 +16,7 @@ import jp.co.lycorp.geojson.Point
 import jp.co.lycorp.geojson.Polygon
 
 /**
- * Deserializer for all GeoJSON object
+ * Deserializer for all GeoJSON objects.
  */
 class GoeJsonObjectDeserializer<T : GeoJsonObject> : JsonDeserializer<T>() {
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): T {

--- a/src/main/kotlin/jp/co/lycorp/geojson/jackson/GoeJsonObjectDeserializer.kt
+++ b/src/main/kotlin/jp/co/lycorp/geojson/jackson/GoeJsonObjectDeserializer.kt
@@ -18,7 +18,7 @@ import jp.co.lycorp.geojson.Polygon
 /**
  * Deserializer for all GeoJSON object
  */
-class GoeJsonObjectDeserializer<T: GeoJsonObject>: JsonDeserializer<T>() {
+class GoeJsonObjectDeserializer<T : GeoJsonObject> : JsonDeserializer<T>() {
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): T {
         val node: JsonNode = p.codec.readTree(p)
         val type = node.get("type")?.asText()

--- a/src/main/kotlin/jp/co/lycorp/geojson/jackson/GoeJsonObjectDeserializer.kt
+++ b/src/main/kotlin/jp/co/lycorp/geojson/jackson/GoeJsonObjectDeserializer.kt
@@ -1,0 +1,39 @@
+package jp.co.lycorp.geojson.jackson
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import jp.co.lycorp.geojson.Feature
+import jp.co.lycorp.geojson.FeatureCollection
+import jp.co.lycorp.geojson.GeoJsonObject
+import jp.co.lycorp.geojson.LineString
+import jp.co.lycorp.geojson.MultiLineString
+import jp.co.lycorp.geojson.MultiPoint
+import jp.co.lycorp.geojson.MultiPolygon
+import jp.co.lycorp.geojson.Point
+import jp.co.lycorp.geojson.Polygon
+
+class GoeJsonObjectDeserializer<T: GeoJsonObject>: JsonDeserializer<T>() {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): T {
+        val node: JsonNode = p.codec.readTree(p)
+        val type = node.get("type")?.asText()
+            ?: throw IllegalArgumentException("Missing 'type' property in GeoJSON")
+
+        val mapper = (p.codec as ObjectMapper)
+
+        val o = when (type) {
+            "Point" -> mapper.treeToValue(node, Point::class.java)
+            "MultiPoint" -> mapper.treeToValue(node, MultiPoint::class.java)
+            "LineString" -> mapper.treeToValue(node, LineString::class.java)
+            "MultiLineString" -> mapper.treeToValue(node, MultiLineString::class.java)
+            "Polygon" -> mapper.treeToValue(node, Polygon::class.java)
+            "MultiPolygon" -> mapper.treeToValue(node, MultiPolygon::class.java)
+            "Feature" -> mapper.treeToValue(node, Feature::class.java)
+            "FeatureCollection" -> mapper.treeToValue(node, FeatureCollection::class.java)
+            else -> throw IllegalArgumentException("Unknown GeoJSON type: $type")
+        }
+        return o as T
+    }
+}

--- a/src/main/kotlin/jp/co/lycorp/geojson/jackson/GoeJsonObjectDeserializer.kt
+++ b/src/main/kotlin/jp/co/lycorp/geojson/jackson/GoeJsonObjectDeserializer.kt
@@ -15,6 +15,9 @@ import jp.co.lycorp.geojson.MultiPolygon
 import jp.co.lycorp.geojson.Point
 import jp.co.lycorp.geojson.Polygon
 
+/**
+ * Deserializer for all GeoJSON object
+ */
 class GoeJsonObjectDeserializer<T: GeoJsonObject>: JsonDeserializer<T>() {
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): T {
         val node: JsonNode = p.codec.readTree(p)

--- a/src/main/kotlin/jp/co/lycorp/geojson/jackson/Helper.kt
+++ b/src/main/kotlin/jp/co/lycorp/geojson/jackson/Helper.kt
@@ -1,0 +1,9 @@
+package jp.co.lycorp.geojson.jackson
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
+/**
+ * Creates [ObjectMapper] instance with a registered [GeoJsonModule].
+ */
+fun geojsonObjectMapper(): ObjectMapper = jacksonObjectMapper().registerModule(GeoJsonModule())

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/BBoxDeserializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/BBoxDeserializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.string.shouldContain
 import io.kotest.property.Exhaustive
@@ -14,7 +13,7 @@ import org.junit.jupiter.api.Test
 import java.io.IOException
 
 class BBoxDeserializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should deserialize to BBox when valid GeoJSON is provided()`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/BBoxSerializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/BBoxSerializationTest.kt
@@ -1,12 +1,11 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import jp.co.lycorp.geojson.BBox
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class BBoxSerializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should serialize BBox when valid BBox is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/FeatureCollectionDeserializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/FeatureCollectionDeserializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import jp.co.lycorp.geojson.BBox
 import jp.co.lycorp.geojson.Feature
 import jp.co.lycorp.geojson.FeatureCollection
@@ -12,7 +11,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class FeatureCollectionDeserializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should deserialize to FeatureCollection when valid GeoJSON with id is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/FeatureCollectionSerializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/FeatureCollectionSerializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import jp.co.lycorp.geojson.BBox
 import jp.co.lycorp.geojson.Feature
 import jp.co.lycorp.geojson.FeatureCollection
@@ -12,7 +11,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class FeatureCollectionSerializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should serialize FeatureCollection when valid feature collection with id is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/FeatureDeserializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/FeatureDeserializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.string.shouldContain
 import io.kotest.property.Exhaustive
@@ -20,7 +19,7 @@ import org.junit.jupiter.api.Test
 import java.io.IOException
 
 class FeatureDeserializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should deserialize to Feature when valid GeoJSON with id of a string is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/FeatureSerializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/FeatureSerializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import jp.co.lycorp.geojson.BBox
 import jp.co.lycorp.geojson.Feature
 import jp.co.lycorp.geojson.FeatureId
@@ -12,7 +11,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class FeatureSerializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should serialize Feature when valid Feature with id of a string is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/GeometryCollectionDeserializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/GeometryCollectionDeserializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import jp.co.lycorp.geojson.GeometryCollection
 import jp.co.lycorp.geojson.LineString
 import jp.co.lycorp.geojson.Point
@@ -11,7 +10,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class GeometryCollectionDeserializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should deserialize to GeometryCollection when valid GeoJSON is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/GeometryCollectionSerializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/GeometryCollectionSerializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import jp.co.lycorp.geojson.GeometryCollection
 import jp.co.lycorp.geojson.LineString
 import jp.co.lycorp.geojson.Point
@@ -10,7 +9,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class GeometryCollectionSerializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should serialize GeometryCollection when valid GeometryCollection is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/LineStringDeserializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/LineStringDeserializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import jp.co.lycorp.geojson.BBox
 import jp.co.lycorp.geojson.LineString
 import jp.co.lycorp.geojson.Position
@@ -10,7 +9,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class LineStringDeserializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should deserialize to LineString when valid GeoJSON is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/LineStringSerializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/LineStringSerializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import jp.co.lycorp.geojson.BBox
 import jp.co.lycorp.geojson.LineString
 import jp.co.lycorp.geojson.Position
@@ -9,7 +8,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class LineStringSerializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should serialize LineString when valid LineString is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/MultiLineStringDeserializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/MultiLineStringDeserializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import jp.co.lycorp.geojson.BBox
 import jp.co.lycorp.geojson.MultiLineString
 import jp.co.lycorp.geojson.Position
@@ -10,7 +9,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class MultiLineStringDeserializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should deserialize to MultiLineString when valid GeoJSON is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/MultiLineStringSerializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/MultiLineStringSerializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import jp.co.lycorp.geojson.BBox
 import jp.co.lycorp.geojson.MultiLineString
 import jp.co.lycorp.geojson.Position
@@ -9,7 +8,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class MultiLineStringSerializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should serialize MultiLineString when valid GeoJSON is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/MultiPointDeserializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/MultiPointDeserializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import jp.co.lycorp.geojson.BBox
 import jp.co.lycorp.geojson.MultiPoint
 import jp.co.lycorp.geojson.Position
@@ -10,7 +9,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class MultiPointDeserializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should deserialize to MultiPoint when valid GeoJSON is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/MultiPointSerializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/MultiPointSerializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import jp.co.lycorp.geojson.BBox
 import jp.co.lycorp.geojson.MultiPoint
 import jp.co.lycorp.geojson.Position
@@ -9,7 +8,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class MultiPointSerializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should serialize to MultiPoint when valid MultiPoint is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/MultiPolygonDeserializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/MultiPolygonDeserializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import jp.co.lycorp.geojson.MultiPolygon
 import jp.co.lycorp.geojson.Position
 import jp.co.lycorp.geojson.extensions.JsonUtils.toCompactedJson
@@ -9,7 +8,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class MultiPolygonDeserializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should deserialize to MultiPolygon when valid GeoJSON is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/MultiPolygonSerializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/MultiPolygonSerializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import jp.co.lycorp.geojson.MultiPolygon
 import jp.co.lycorp.geojson.Position
 import jp.co.lycorp.geojson.extensions.JsonUtils.toCompactedJson
@@ -8,7 +7,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class MultiPolygonSerializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should serialize MultiPolygon when valid MultiPolygon is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/PointDeserializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/PointDeserializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import jp.co.lycorp.geojson.BBox
 import jp.co.lycorp.geojson.Point
 import jp.co.lycorp.geojson.Position
@@ -10,7 +9,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class PointDeserializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should deserialize to Point when valid GeoJSON is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/PointSerializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/PointSerializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import jp.co.lycorp.geojson.Point
 import jp.co.lycorp.geojson.Position
 import jp.co.lycorp.geojson.extensions.JsonUtils.toCompactedJson
@@ -8,7 +7,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class PointSerializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should serialize Point when valid Point is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/PolygonDeserializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/PolygonDeserializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import jp.co.lycorp.geojson.BBox
 import jp.co.lycorp.geojson.Polygon
 import jp.co.lycorp.geojson.Position
@@ -10,7 +9,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class PolygonDeserializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should deserialize to Polygon when valid GeoJSON without holes is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/PolygonSerializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/PolygonSerializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import jp.co.lycorp.geojson.BBox
 import jp.co.lycorp.geojson.Polygon
 import jp.co.lycorp.geojson.Position
@@ -9,7 +8,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class PolygonSerializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should serialize Polygon when valid Polygon without holes is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/PositionDeserializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/PositionDeserializationTest.kt
@@ -1,6 +1,5 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.string.shouldContain
 import io.kotest.property.Exhaustive
@@ -14,7 +13,7 @@ import org.junit.jupiter.api.Test
 import java.io.IOException
 
 class PositionDeserializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should deserialize to Position when valid GeoJSON is provided`() {

--- a/src/test/kotlin/jp/co/lycorp/geojson/jackson/PositionSerializationTest.kt
+++ b/src/test/kotlin/jp/co/lycorp/geojson/jackson/PositionSerializationTest.kt
@@ -1,12 +1,11 @@
 package jp.co.lycorp.geojson.jackson
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import jp.co.lycorp.geojson.Position
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class PositionSerializationTest {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = geojsonObjectMapper()
 
     @Test
     fun `should serialize Position when valid BBox is provided`() {


### PR DESCRIPTION
## Issue

No issue

## Summary

Currently geojson-kt is tightly coupled with jackson. However, not all users use jackson.

Therefore, this PR first confines the dependency on jackson to the `jp.co.lycorp.geojson.jackson` package.

In the future geojson-kt should be provided as a pure kotlin library with no dependency on jackson, and integration with jackson should be provided as a separate library.

## Changes

- Add `GeoJsonModule` for integration with jackson and geojson-kt
- Remove all dependencies on jackson from GeoJSON objects

## Checklist

- [x] Link to issue specified (N/A)
- [x] Implementation satisfies the stated objective(s)
- [x] Test(s) added as appropriate (N/A)
- [x] Documentation created/updated (N/A)