### PR TITLE
fix: fix action-junit-report fails on workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,12 +31,13 @@ jobs:
       - name: Run test
         run: ./gradlew check --no-daemon
 
-      - name: Publish test reports
-        uses: mikepenz/action-junit-report@v3
+      - name: Upload Test Report
+        uses: actions/upload-artifact@v3
         if: always()
         with:
-          report_paths: |
-            **/build/test-results/test/TEST-*.xml
+          name: junit-test-results
+          path: '**/build/test-results/test/TEST-*.xml'
+          retention-days: 1
 
       - name: Create coverage report
         if: ${{ github.event.pull_request }}
@@ -54,3 +55,30 @@ jobs:
           min-coverage-overall: 80
           min-coverage-changed-files: 80
           coverage-counter-type: LINE
+
+---
+name: report
+on:
+  workflow_run:
+    workflows: [ Upload Test Report ]
+    types: [ completed ]
+
+permissions:
+  checks: write
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Test Report
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          name: junit-test-results
+          workflow: ${{ github.event.workflow.id }}
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v5
+        with:
+          commit: ${{github.event.workflow_run.head_sha}}
+          report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         run: ./gradlew check --no-daemon
 
       - name: Upload Test Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: junit-test-results
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Test Report
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v10
         with:
           name: junit-test-results
           workflow: ${{ github.event.workflow.id }}


### PR DESCRIPTION
## Issue

https://github.com/line/geojson-kt/issues/6

## Summary

- Separate `action-junit-report` jobs from workflow

## Changes

- The workflow was divided according to the following
- refs: https://github.com/mikepenz/action-junit-report?tab=readme-ov-file#pr-run-permissions

> Additionally for [security reasons](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/), the github token used for pull_request workflows is [marked as read-only](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token). If you want to post checks to a PR from an external repository, you will need to use a separate workflow which has a read/write token, or use a PAT with elevated permissions.

## Notes / References

- Another method seems to be to set `annotate_only: true` for PRs from external repositories
- https://github.com/mikepenz/action-junit-report/issues/23#issuecomment-1717688566


## Checklist

- [x] Link to issue specified
- [ ] Implementation satisfies the stated objective(s)
- [ ] Test(s) added as appropriate
- [ ] Documentation created/updated